### PR TITLE
mejoras-multiples-front

### DIFF
--- a/assets/js/whq_wcchp_cart.js
+++ b/assets/js/whq_wcchp_cart.js
@@ -14,11 +14,20 @@ jQuery(document).ready(function( $ ) {
 			}
 		});
 
-		//Load cities
-		jQuery('body').on('change', '#calc_shipping_state', function() {
-			whq_wcchp_code_reg = jQuery('#calc_shipping_state').val();
-
-			whq_wcchp_cart_load_cities( whq_wcchp_code_reg );
+		//Manage regions and load cities
+		jQuery('body').on('change', '#calc_shipping_whq_regopt', function() {
+			var whq_wcchp_region_option = jQuery('#calc_shipping_whq_regopt').val();
+			var whq_wcchp_region_array = whq_wcchp_region_option.split('|');
+			jQuery('#calc_shipping_state').val(whq_wcchp_region_array[1]);
+			jQuery('#calc_shipping_whq_region').val(whq_wcchp_region_array[0]);
+			whq_wcchp_cart_load_cities( whq_wcchp_region_array[0] );
+		});
+		//Manage cities
+		jQuery('body').on('change', '#calc_shipping_whq_citopt', function() {
+			var whq_wcchp_city_option = jQuery('#calc_shipping_whq_citopt').val();
+			var whq_wcchp_city_array = whq_wcchp_city_option.split('|');
+			jQuery('#calc_shipping_city').val(whq_wcchp_city_array[1]);
+			jQuery('#calc_shipping_whq_city').val(whq_wcchp_city_array[0]);
 		});
 	}
 
@@ -50,7 +59,6 @@ function whq_wcchp_cart_chile_detected() {
 	if( jQuery('body').hasClass('wc-chilexpress-enabled') ) {
 		return;
 	}
-
 	jQuery('body').addClass('wc-chilexpress-enabled');
 
 	whq_wcchp_cart_inputs_replace();
@@ -67,21 +75,31 @@ function whq_wcchp_cart_chile_detected() {
 				//Chilexpress down
 				whq_wcchp_cart_inputs_restore();
 			} else {
-				jQuery('#calc_shipping_state').prop('disabled', false).empty().append('<option value=""></option>');
+				jQuery('#calc_shipping_whq_regopt').prop('disabled', false).empty().append('<option value="|"></option>');
 
+				var whq_wcchp_region_name = jQuery('#calc_shipping_state').val();
+				var whq_wcchp_region_code = '';
 				jQuery(response.data).each(function( i ) {
-					jQuery('#calc_shipping_state').append('<option value="'+response.data[i]['idRegion']+'"> '+response.data[i]['GlsRegion']+' </option>');
+					if( response.data[i]['GlsRegion'] == whq_wcchp_region_name ) {
+						whq_wcchp_region_code = response.data[i]['idRegion'];
+						jQuery('#calc_shipping_whq_region').val(whq_wcchp_region_code);
+						jQuery('#calc_shipping_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'" selected> '+response.data[i]['GlsRegion']+' </option>');
+					} else {
+						jQuery('#calc_shipping_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'"> '+response.data[i]['GlsRegion']+' </option>');
+					}
 				});
 
-				if( !jQuery('#calc_shipping_state').hasClass('select2-hidden-accessible') ) {
-					jQuery('#calc_shipping_state').select2();
+				if( !jQuery('#calc_shipping_whq_regopt').hasClass('select2-hidden-accessible') ) {
+					jQuery('#calc_shipping_whq_regopt').select2();
 					jQuery('.select2-container').css('width', '100%'); //Select2 width fix
-
 					jQuery('#calc_shipping_state_field').unblock();
 				}
 
-				//Let user know that he/she needs to select a Region first
-				jQuery('#calc_shipping_city').prop('disabled', false).empty().append('<option value="">Selecciona tu región primero, por favor.</option>');
+				if( whq_wcchp_region_code != '' ) {
+					whq_wcchp_cart_load_cities( whq_wcchp_region_code );
+				} else {
+					jQuery('#calc_shipping_whq_citopt').prop('disabled', false).empty().append('<option value="">Selecciona la región primero.</option>');
+				}
 			}
 		}
 	});
@@ -91,7 +109,6 @@ function whq_wcchp_cart_load_cities( region_code ) {
 	if(region_code == '') {
 		region_code = '99'; //Bring it on!
 	}
-
 	jQuery.ajax({
 		url: woocommerce_params.ajax_url,
 		data: {
@@ -103,20 +120,39 @@ function whq_wcchp_cart_load_cities( region_code ) {
 		datatype: 'application/json',
 		success: function( response ) {
 			if(response.success === true) {
-				jQuery('#calc_shipping_city').prop('disabled', false).empty().append('<option value=""></option>');
+				jQuery('#calc_shipping_whq_citopt').prop('disabled', false).empty().append('<option value=""></option>');
 
+				var whq_wcchp_city_name = jQuery('#calc_shipping_city').val();
+				var whq_wcchp_city_code = '';
 				if( jQuery.isArray( response.data ) ) {
 					jQuery(response.data).each(function( i ) {
-						jQuery('#calc_shipping_city').append('<option value="'+response.data[i]['CodComuna']+'"> '+response.data[i]['GlsComuna']+' </option>');
+						if( response.data[i]['GlsComuna'] == whq_wcchp_city_name ) {
+							whq_wcchp_city_code = response.data[i]['CodComuna'];
+							jQuery('#calc_shipping_whq_city').val(whq_wcchp_city_code);
+							jQuery('#calc_shipping_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'" selected> '+response.data[i]['GlsComuna']+' </option>');
+						} else {
+							jQuery('#calc_shipping_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'"> '+response.data[i]['GlsComuna']+' </option>');
+						}
 					});
 				} else {
-					jQuery('#calc_shipping_city').append('<option value="'+response.data['CodComuna']+'"> '+response.data['GlsComuna']+' </option>');
+					if( response.data['GlsComuna'] == whq_wcchp_city_name ) {
+						whq_wcchp_city_code = response.data['CodComuna'];
+						jQuery('#calc_shipping_whq_city').val(whq_wcchp_city_code);
+						jQuery('#calc_shipping_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'" selected> '+response.data['GlsComuna']+' </option>');
+					} else {
+						jQuery('#calc_shipping_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'"> '+response.data['GlsComuna']+' </option>');
+					}
 				}
 
-				if( !jQuery('#calc_shipping_city').hasClass('select2-hidden-accessible') ) {
-					jQuery('#calc_shipping_city').select2();
-					jQuery('.select2-container').css('width', '100%'); //Select2 width fix
+				$code_and_city = jQuery('#calc_shipping_whq_city').val() + '|' + jQuery('#calc_shipping_city').val();
+				if ( $code_and_city != jQuery('#calc_shipping_whq_citopt').val() ) {
+					jQuery('#calc_shipping_whq_city').val('');
+					jQuery('#calc_shipping_city').val('');
+				}
 
+				if( !jQuery('#calc_shipping_whq_citopt').hasClass('select2-hidden-accessible') ) {
+					jQuery('#calc_shipping_whq_citopt').select2();
+					jQuery('.select2-container').css('width', '100%'); //Select2 width fix
 					jQuery('#calc_shipping_city_field').unblock();
 				}
 			}
@@ -126,9 +162,19 @@ function whq_wcchp_cart_load_cities( region_code ) {
 
 function whq_wcchp_cart_inputs_replace() {
 	if( jQuery('#calc_shipping_city, #calc_shipping_state').is('input') ) {
-		//Show city field
+		//Show city field and hide postcode field
 		jQuery('#calc_shipping_city_field').show();
 		jQuery('#calc_shipping_postcode_field').hide();
+
+		//Inserts new fields for manipulation and select
+		jQuery("#calc_shipping_state").after('<input type="text" class="input-text" name="calc_shipping_whq_region" id="calc_shipping_whq_region" />');
+		jQuery("#calc_shipping_whq_region").after('<select id="calc_shipping_whq_regopt" name="calc_shipping_whq_regopt" disabled="disabled"></select>');
+		jQuery('#calc_shipping_state').hide();
+		jQuery('#calc_shipping_whq_region').hide();
+		jQuery("#calc_shipping_city").after('<input type="text" class="input-text" name="calc_shipping_whq_city" id="calc_shipping_whq_city" />');
+		jQuery("#calc_shipping_whq_city").after('<select id="calc_shipping_whq_citopt" name="calc_shipping_whq_citopt" disabled="disabled"></select>');
+		jQuery('#calc_shipping_city').hide();
+		jQuery('#calc_shipping_whq_city').hide();
 
 		//Block UI
 		jQuery('#calc_shipping_city_field, #calc_shipping_state_field').block({
@@ -138,26 +184,24 @@ function whq_wcchp_cart_inputs_replace() {
 				opacity: 0.6
 			}
 		});
-
-		//Replace with selects
-		jQuery("#calc_shipping_state").replaceWith('<select id="calc_shipping_state" name="calc_shipping_state" disabled="disabled"></select>')
-		jQuery("#calc_shipping_city").replaceWith('<select id="calc_shipping_city" name="calc_shipping_city" disabled="disabled"></select>');
 	}
 }
 
 function whq_wcchp_cart_inputs_restore() {
-	if( jQuery('#calc_shipping_city, #calc_shipping_state').is('select') ) {
-		//Hide city field
+	if( jQuery('#calc_shipping_whq_citopt, #calc_shipping_whq_regopt').is('select') ) {
+		//Hide city field and show postcode
 		jQuery('#calc_shipping_city_field').hide();
 		jQuery('#calc_shipping_postcode_field').show();
+		jQuery('#calc_shipping_state').show();
 
-		//Replace with inputs
-		jQuery("#calc_shipping_state").replaceWith('<input type="text" class="input-text" name="calc_shipping_state" id="calc_shipping_state" placeholder="State / County" />');
-		jQuery("#calc_shipping_city").replaceWith('<input type="text" class="input-text" name="calc_shipping_city" id="calc_shipping_city" placeholder="City" />');
-
-		//Avoid duplicated select2
-		jQuery('#calc_shipping_city').next('.select2-container').remove();
-
+		//Remove inserted fields
+		jQuery("#calc_shipping_whq_region").remove();
+		jQuery('#calc_shipping_whq_regopt').next('.select2-container').remove();
+		jQuery("#calc_shipping_whq_regopt").remove();
+		jQuery("#calc_shipping_whq_city").remove();
+		jQuery('#calc_shipping_whq_citopt').next('.select2-container').remove();
+		jQuery("#calc_shipping_whq_citopt").remove();
+		
 		//Remove our trigger class from body
 		jQuery('body').removeClass('wc-chilexpress-enabled');
 

--- a/assets/js/whq_wcchp_checkout.js
+++ b/assets/js/whq_wcchp_checkout.js
@@ -215,7 +215,7 @@ function whq_wcchp_checkout_load_cities_billing( region_code ) {
 				$code_and_city = jQuery('#billing_whq_city').val() + '|' + jQuery('#billing_city').val();
 				if ( $code_and_city != jQuery('#billing_whq_citopt').val() ) {
 					jQuery('#billing_whq_city').val('');
-					jQuery('#billing_city').val('');
+					jQuery('#billing_city').val(' ');
 				}
 				if( !jQuery('#billing_whq_citopt').hasClass('select2-hidden-accessible') ) {
 					jQuery('#billing_whq_citopt').select2();
@@ -266,7 +266,7 @@ function whq_wcchp_checkout_load_cities_shipping( region_code ) {
 				$code_and_city = jQuery('#shipping_whq_city').val() + '|' + jQuery('#shipping_city').val();
 				if ( $code_and_city != jQuery('#shipping_whq_citopt').val() ) {
 					jQuery('#shipping_whq_city').val('');
-					jQuery('#shipping_city').val('');
+					jQuery('#shipping_city').val(' ');
 				}
 				if( !jQuery('#shipping_whq_citopt').hasClass('select2-hidden-accessible') ) {
 					jQuery('#shipping_whq_citopt').select2();

--- a/assets/js/whq_wcchp_checkout.js
+++ b/assets/js/whq_wcchp_checkout.js
@@ -74,7 +74,7 @@ jQuery(document).ready(function( $ ) {
 			if( ! jQuery('body').hasClass('wc-chilexpress-enabled') && jQuery('#shipping_method_0_chilexpress').length ) {
 				jQuery('#shipping_method_0_chilexpress').prop('disabled', true).prop('selected', false);
 
-				jQuery('form.woocommerce-checkout').prepend('<div class="whq_wcchp_chilexpress_error woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"><ul class="woocommerce-error"><li><strong>Chilexpress no se encuentra disponible por el momento. Por favor, iténtelo más tarde.</li></ul></div>');
+				jQuery('form.woocommerce-checkout').prepend('<div class="whq_wcchp_chilexpress_error woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"><ul class="woocommerce-error"><li><strong>Chilexpress no se encuentra disponible por el momento. Por favor, inténtelo más tarde.</li></ul></div>');
 				jQuery('html, body').animate({ scrollTop: 0 }, 'normal');
 
 				setTimeout(function() {

--- a/assets/js/whq_wcchp_checkout.js
+++ b/assets/js/whq_wcchp_checkout.js
@@ -6,12 +6,10 @@ var whq_wcchp_chilexpress_cost;
 jQuery(document).ready(function( $ ) {
 	//Only on WooCommerce's Checkout
 	if( jQuery('.woocommerce-checkout').length ) {
-		//CL detected
+		//CL detection
 		if(jQuery('#billing_country').val() == 'CL' || jQuery('#shipping_country').val() == 'CL') {
 			whq_wcchp_checkout_chile_detected();
 		}
-
-		//CL detected
 		jQuery('body').on('change', '#billing_country', function() {
 			if(jQuery('#billing_country').val() == 'CL') {
 				whq_wcchp_checkout_chile_detected();
@@ -19,8 +17,6 @@ jQuery(document).ready(function( $ ) {
 				whq_wcchp_checkout_restore();
 			}
 		});
-
-		//CL detected
 		jQuery('body').on('change', '#shipping_country', function() {
 			if(jQuery('#shipping_country').val() == 'CL') {
 				whq_wcchp_checkout_chile_detected();
@@ -29,15 +25,35 @@ jQuery(document).ready(function( $ ) {
 			}
 		});
 
-		//Load cities
-		jQuery('body').on('change', '#billing_state, #shipping_state', function() {
-			if( jQuery('#ship-to-different-address-checkbox').is(':checked') ) {
-				whq_wcchp_code_reg = jQuery('#shipping_state').val();
-			} else {
-				whq_wcchp_code_reg = jQuery('#billing_state').val();
-			}
-
-			whq_wcchp_checkout_load_cities( whq_wcchp_code_reg );
+		//Manage billing regions and load cities
+		jQuery('body').on('change', '#billing_whq_regopt', function() {
+			var whq_wcchp_regbil_option = jQuery('#billing_whq_regopt').val();
+			var whq_wcchp_regbil_array = whq_wcchp_regbil_option.split('|');
+			jQuery('#billing_state').val(whq_wcchp_regbil_array[1]);
+			jQuery('#billing_whq_region').val(whq_wcchp_regbil_array[0]);
+			whq_wcchp_checkout_load_cities_billing( whq_wcchp_regbil_array[0] );
+		});
+		//Manage shipping regions and load cities
+		jQuery('body').on('change', '#shipping_whq_regopt', function() {
+			var whq_wcchp_regshi_option = jQuery('#shipping_whq_regopt').val();
+			var whq_wcchp_regshi_array = whq_wcchp_regshi_option.split('|');
+			jQuery('#shipping_state').val(whq_wcchp_regshi_array[1]);
+			jQuery('#shipping_whq_region').val(whq_wcchp_regshi_array[0]);
+			whq_wcchp_checkout_load_cities_shipping( whq_wcchp_regshi_array[0] );
+		});
+		//Manage billing cities
+		jQuery('body').on('change', '#billing_whq_citopt', function() {
+			var whq_wcchp_city_option = jQuery('#billing_whq_citopt').val();
+			var whq_wcchp_city_array = whq_wcchp_city_option.split('|');
+			jQuery('#billing_city').val(whq_wcchp_city_array[1]);
+			jQuery('#billing_whq_city').val(whq_wcchp_city_array[0]);
+		});
+		//Manage shipping cities
+		jQuery('body').on('change', '#shipping_whq_citopt', function() {
+			var whq_wcchp_city_option = jQuery('#shipping_whq_citopt').val();
+			var whq_wcchp_city_array = whq_wcchp_city_option.split('|');
+			jQuery('#shipping_city').val(whq_wcchp_city_array[1]);
+			jQuery('#shipping_whq_city').val(whq_wcchp_city_array[0]);
 		});
 
 		//Fix Select2 width
@@ -77,7 +93,7 @@ jQuery(document).ready(function( $ ) {
 				if( whq_wcchp_chilexpress_cost == '' && jQuery('#shipping_method_0_chilexpress').is(':checked') ) {
 					jQuery('#shipping_method_0_chilexpress').prop('disabled', true).prop('selected', false);
 
-					jQuery('form.woocommerce-checkout').prepend('<div class="whq_wcchp_chilexpress_error woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"><ul class="woocommerce-error"><li><strong>Chilexpress no se encuentra disponible por el momento. Por favor, iténtelo más tarde.</li></ul></div>');
+					jQuery('form.woocommerce-checkout').prepend('<div class="whq_wcchp_chilexpress_error woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout"><ul class="woocommerce-error"><li><strong>Chilexpress no se encuentra disponible en este momento. Por favor, iténtalo en unos minutos.</li></ul></div>');
 					jQuery('html, body').animate({ scrollTop: 0 }, 'normal');
 
 					setTimeout(function() {
@@ -97,7 +113,6 @@ function whq_wcchp_checkout_chile_detected() {
 	if( jQuery('body').hasClass('wc-chilexpress-enabled') ) {
 		return;
 	}
-
 	jQuery('body').addClass('wc-chilexpress-enabled');
 
 	whq_wcchp_checkout_inputs_replace();
@@ -113,35 +128,57 @@ function whq_wcchp_checkout_chile_detected() {
 			if(response.success === false) {
 				//Chilexpress down
 				whq_wcchp_checkout_restore();
-
 				jQuery('#shipping_city_field, #shipping_state_field').unblock();
 				jQuery('#billing_city_field, #billing_state_field').unblock();
 			} else {
-				whq_wcchp_checkout_inputs_replace(); //Why WooCommerce override the first one?
+				//whq_wcchp_checkout_inputs_replace(); //Why WooCommerce override the first one?
+				jQuery('#billing_whq_regopt, #shipping_whq_regopt').prop('disabled', false).empty().append('<option value=""></option>');
 
-				jQuery('#billing_state, #shipping_state').prop('disabled', false).empty().append('<option value=""></option>');
-
+				var whq_wcchp_regbil_name = jQuery('#billing_state').val();
+				var whq_wcchp_regbil_code = '';
+				var whq_wcchp_regshi_name = jQuery('#shipping_state').val();
+				var whq_wcchp_regshi_code = '';
 				jQuery(response.data).each(function( i ) {
-					jQuery('#billing_state, #shipping_state').append('<option value="'+response.data[i]['idRegion']+'"> '+response.data[i]['GlsRegion']+' </option>');
+					if( response.data[i]['GlsRegion'] == whq_wcchp_regbil_name ) {
+						whq_wcchp_regbil_code = response.data[i]['idRegion'];
+						jQuery('#billing_whq_region').val(whq_wcchp_regbil_code);
+						jQuery('#billing_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'" selected> '+response.data[i]['GlsRegion']+' </option>');
+					} else {
+						jQuery('#billing_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'"> '+response.data[i]['GlsRegion']+' </option>');
+					}
+					if( response.data[i]['GlsRegion'] == whq_wcchp_regshi_name ) {
+						whq_wcchp_regshi_code = response.data[i]['idRegion'];
+						jQuery('#shipping_whq_region').val(whq_wcchp_regshi_code);
+						jQuery('#shipping_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'" selected> '+response.data[i]['GlsRegion']+' </option>');
+					} else {
+						jQuery('#shipping_whq_regopt').append('<option value="'+response.data[i]['idRegion']+'|'+response.data[i]['GlsRegion']+'"> '+response.data[i]['GlsRegion']+' </option>');
+					}
 				});
 
-				if( !jQuery('#billing_state, #shipping_state').hasClass('select2-hidden-accessible') ) {
-					jQuery('#billing_state, #shipping_state').select2();
+				if( !jQuery('#billing_whq_regopt, #shipping_whq_regopt').hasClass('select2-hidden-accessible') ) {
+					jQuery('#billing_whq_regopt, #shipping_whq_regopt').select2();
 					jQuery('#billing_state_field, #shipping_state_field').unblock();
 				}
 
-				//Let user know that he/she needs to select a Region first
-				jQuery('#billing_city, #shipping_city').prop('disabled', false).empty().append('<option value="">Selecciona tu región primero, por favor.</option>');
+				if( whq_wcchp_regbil_code != '' ) {
+					whq_wcchp_checkout_load_cities_billing( whq_wcchp_regbil_code );
+				} else {
+					jQuery('#billing_whq_citopt').prop('disabled', false).empty().append('<option value="">Selecciona la región primero.</option>');
+				}
+				if( whq_wcchp_regshi_code != '' ) {
+					whq_wcchp_checkout_load_cities_shipping( whq_wcchp_regshi_code );
+				} else {
+					jQuery('#shipping_whq_citopt').prop('disabled', false).empty().append('<option value="">Selecciona la región primero.</option>');
+				}
 			}
 		}
 	});
 }
 
-function whq_wcchp_checkout_load_cities( region_code ) {
+function whq_wcchp_checkout_load_cities_billing( region_code ) {
 	if(region_code == '') {
 		region_code = '99'; //Bring it on!
 	}
-
 	jQuery.ajax({
 		url: woocommerce_params.ajax_url,
 		data: {
@@ -153,18 +190,88 @@ function whq_wcchp_checkout_load_cities( region_code ) {
 		datatype: 'application/json',
 		success: function( response ) {
 			if(response.success === true) {
-				jQuery('#billing_city, #shipping_city').prop('disabled', false).empty().append('<option value=""></option>');
-
+				jQuery('#billing_whq_citopt').prop('disabled', false).empty().append('<option value=""></option>');
+				var whq_wcchp_city_name = jQuery('#billing_city').val();
+				var whq_wcchp_city_code = '';
 				if( jQuery.isArray( response.data ) ) {
 					jQuery(response.data).each(function( i ) {
-						jQuery('#billing_city, #shipping_city').append('<option value="'+response.data[i]['CodComuna']+'"> '+response.data[i]['GlsComuna']+' </option>');
+						if( response.data[i]['GlsComuna'] == whq_wcchp_city_name ) {
+							whq_wcchp_city_code = response.data[i]['CodComuna'];
+							jQuery('#billing_whq_city').val(whq_wcchp_city_code);
+							jQuery('#billing_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'" selected> '+response.data[i]['GlsComuna']+' </option>');
+						} else {
+							jQuery('#billing_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'"> '+response.data[i]['GlsComuna']+' </option>');
+						}
 					});
 				} else {
-					jQuery('#billing_city, #shipping_city').append('<option value="'+response.data['CodComuna']+'"> '+response.data['GlsComuna']+' </option>');
+					if( response.data['GlsComuna'] == whq_wcchp_city_name ) {
+						whq_wcchp_city_code = response.data['CodComuna'];
+						jQuery('#billing_whq_city').val(whq_wcchp_city_code);
+						jQuery('#billing_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'" selected> '+response.data['GlsComuna']+' </option>');
+					} else {
+						jQuery('#billing_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'"> '+response.data['GlsComuna']+' </option>');
+					}
 				}
+				$code_and_city = jQuery('#billing_whq_city').val() + '|' + jQuery('#billing_city').val();
+				if ( $code_and_city != jQuery('#billing_whq_citopt').val() ) {
+					jQuery('#billing_whq_city').val('');
+					jQuery('#billing_city').val('');
+				}
+				if( !jQuery('#billing_whq_citopt').hasClass('select2-hidden-accessible') ) {
+					jQuery('#billing_whq_citopt').select2();
+					jQuery('#billing_city_field').unblock();
+				}
+			}
+		}
+	});
+}
 
-				jQuery('#billing_city, #shipping_city').select2();
-				jQuery('#billing_city_field, #billing_state_field').unblock();
+function whq_wcchp_checkout_load_cities_shipping( region_code ) {
+	if(region_code == '') {
+		region_code = '99'; //Bring it on!
+	}
+	jQuery.ajax({
+		url: woocommerce_params.ajax_url,
+		data: {
+			action: 'whq_wcchp_cities_ajax',
+			codregion: region_code,
+			codtipocobertura: '2'
+		},
+		type: 'POST',
+		datatype: 'application/json',
+		success: function( response ) {
+			if(response.success === true) {
+				jQuery('#shipping_whq_citopt').prop('disabled', false).empty().append('<option value=""></option>');
+				var whq_wcchp_city_name = jQuery('#shipping_city').val();
+				var whq_wcchp_city_code = '';
+				if( jQuery.isArray( response.data ) ) {
+					jQuery(response.data).each(function( i ) {
+						if( response.data[i]['GlsComuna'] == whq_wcchp_city_name ) {
+							whq_wcchp_city_code = response.data[i]['CodComuna'];
+							jQuery('#shipping_whq_city').val(whq_wcchp_city_code);
+							jQuery('#shipping_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'" selected> '+response.data[i]['GlsComuna']+' </option>');
+						} else {
+							jQuery('#shipping_whq_citopt').append('<option value="'+response.data[i]['CodComuna']+'|'+response.data[i]['GlsComuna']+'"> '+response.data[i]['GlsComuna']+' </option>');
+						}
+					});
+				} else {
+					if( response.data['GlsComuna'] == whq_wcchp_city_name ) {
+						whq_wcchp_city_code = response.data['CodComuna'];
+						jQuery('#shipping_whq_city').val(whq_wcchp_city_code);
+						jQuery('#shipping_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'" selected> '+response.data['GlsComuna']+' </option>');
+					} else {
+						jQuery('#shipping_whq_citopt').append('<option value="'+response.data['CodComuna']+'|'+response.data['GlsComuna']+'"> '+response.data['GlsComuna']+' </option>');
+					}
+				}
+				$code_and_city = jQuery('#shipping_whq_city').val() + '|' + jQuery('#shipping_city').val();
+				if ( $code_and_city != jQuery('#shipping_whq_citopt').val() ) {
+					jQuery('#shipping_whq_city').val('');
+					jQuery('#shipping_city').val('');
+				}
+				if( !jQuery('#shipping_whq_citopt').hasClass('select2-hidden-accessible') ) {
+					jQuery('#shipping_whq_citopt').select2();
+					jQuery('#shipping_city_field').unblock();
+				}
 			}
 		}
 	});
@@ -172,42 +279,61 @@ function whq_wcchp_checkout_load_cities( region_code ) {
 
 function whq_wcchp_checkout_inputs_replace() {
 	if( jQuery('#billing_city, #shipping_city').is('input') ) {
-		jQuery('#billing_city_field, #billing_state_field').block({
+		//Inserts new fields for manipulation and select
+		jQuery("#billing_city").after('<input type="text" class="input-text" name="billing_whq_city" id="billing_whq_city" />');
+		jQuery("#billing_whq_city").after('<select id="billing_whq_citopt" name="billing_whq_citopt" disabled="disabled"></select>');
+		jQuery('#billing_city').hide();
+		jQuery('#billing_whq_city').hide();
+		jQuery("#shipping_city").after('<input type="text" class="input-text" name="shipping_whq_city" id="shipping_whq_city" />');
+		jQuery("#shipping_whq_city").after('<select id="shipping_whq_citopt" name="shipping_whq_citopt" disabled="disabled"></select>');
+		jQuery('#shipping_city').hide();
+		jQuery('#shipping_whq_city').hide();
+		jQuery('#billing_city_field, #shipping_city_field').block({
 			message: null,
 			overlayCSS: {
 				background: '#fff',
 				opacity: 0.6
 			}
 		});
-
-		jQuery("#billing_city").replaceWith('<select id="billing_city" name="billing_city" disabled="disabled"></select>')
-		jQuery("#shipping_city").replaceWith('<select id="shipping_city" name="shipping_city" disabled="disabled"></select>');
 	}
-
 	if( jQuery('#billing_state, #shipping_state').is('input') ) {
-		jQuery('#shipping_city_field, #shipping_state_field').block({
+		//Inserts new fields for manipulation and select
+		jQuery("#billing_state").after('<input type="text" class="input-text" name="billing_whq_region" id="billing_whq_region" />');
+		jQuery("#billing_whq_region").after('<select id="billing_whq_regopt" name="billing_whq_regopt" disabled="disabled"></select>');
+		jQuery('#billing_state').hide();
+		jQuery('#billing_whq_region').hide();
+		jQuery("#shipping_state").after('<input type="text" class="input-text" name="shipping_whq_region" id="shipping_whq_region" />');
+		jQuery("#shipping_whq_region").after('<select id="shipping_whq_regopt" name="shipping_whq_regopt" disabled="disabled"></select>');
+		jQuery('#shipping_state').hide();
+		jQuery('#shipping_whq_region').hide();
+		jQuery('#billing_state_field, #shipping_state_field').block({
 			message: null,
 			overlayCSS: {
 				background: '#fff',
 				opacity: 0.6
 			}
 		});
-
-		jQuery("#billing_state").replaceWith('<select id="billing_state" name="billing_state" disabled="disabled"></select>');
-		jQuery("#shipping_state").replaceWith( '<select id="shipping_state" name="shipping_state" disabled="disabled"></select>' );
 	}
 }
 
 function whq_wcchp_checkout_restore() {
-	if( jQuery('#billing_city, #shipping_city').is('select') ) {
-		jQuery("#billing_city").replaceWith('<input type="text" class="input-text" name="billing_city" id="billing_city" placeholder=""  value="" autocomplete="address-level2" />');
-		jQuery("#shipping_city").replaceWith('<input type="text" class="input-text" name="shipping_city" id="shipping_city" placeholder=""  value="" autocomplete="address-level2" />');
+	//Remove inserted fields
+	if( jQuery('#billing_whq_citopt, #shipping_whq_citopt').is('select') ) {
+		jQuery("#billing_whq_city").remove();
+		jQuery("#billing_whq_citopt").next('.select2-container').remove();
+		jQuery("#billing_whq_citopt").remove();
+		jQuery("#shipping_whq_city").remove();
+		jQuery("#shipping_whq_citopt").next('.select2-container').remove();
+		jQuery("#shipping_whq_citopt").remove();
 	}
-
-	if( jQuery('#billing_state, #shipping_state').is('select') ) {
-		jQuery("#billing_state").replaceWith('<input type="text" class="input-text" value=""  placeholder="" name="billing_state" id="billing_state" autocomplete="address-level1" />');
-		jQuery("#shipping_state").replaceWith('<input type="text" class="input-text" value=""  placeholder="" name="shipping_state" id="shipping_state" autocomplete="address-level1" />');
+	if( jQuery('#billing_whq_regopt, #shipping_whq_regopt').is('select') ) {
+		jQuery("#billing_whq_region").remove();
+		jQuery("#billing_whq_regopt").next('.select2-container').remove();
+		jQuery("#billing_whq_regopt").remove();
+		jQuery("#shipping_whq_region").remove();
+		jQuery("#shipping_whq_regopt").next('.select2-container').remove();
+		jQuery("#shipping_whq_regopt").remove();
 	}
-
+	//Remove our trigger class from body
 	jQuery('body').removeClass('wc-chilexpress-enabled');
 }

--- a/classes/WC_WHQ_Chilexpress_Shipping.php
+++ b/classes/WC_WHQ_Chilexpress_Shipping.php
@@ -324,6 +324,15 @@ function whq_wcchp_init_class() {
 				}
 
 				if( !is_null( $city ) ) {
+					//Transform city name to city code
+					$cities = $this->get_cities();
+					foreach ( $cities as $CodComuna => $GlsComuna ) {
+						if ( $city == $GlsComuna ) {
+							$city = $CodComuna;
+							break;
+						}
+					}
+
 					$chp_cost   = whq_wcchp_get_tarificacion($city, $this->shipping_origin, $weight, $length, $width, $height);
 					$final_cost = 0;
 


### PR DESCRIPTION
@TCattd,

Implementé diversas mejoras en el manejo global de las regiones y ciudades.

En calculadora de envíos:
- Rescata correctamente los valores que tengas registrados como cliente (región/ciudad) y presenta los combobox con la región/ciudad preseleccionada (esto sólo una vez que ya hayas realizado alguna compra con estas mejoras, de lo contrario rescata los códigos y no presenta ningún valor preseleccionado).
- Permite realizar diversos cálculos conservando los valores de la región y ciudad.
- Traspasa correctamente los valores de la región y ciudad de la calculadora al checkout (no tienes que seleccionarlos nuevamente).

En el checkout:
- Independiza el cálculo con las direcciones de facturación y envío (antes cambiabas uno de los combos de facturación y se cambiaba también el de envío o viceversa).
- Traspasa correctamente los valores a la orden y no como códigos de Chilexpress (este problema era una lata para procesar las órdenes posteriormente).

Con esto el plugin está quedando de lujo.

Si tienes alguna duda me llamas (998222485)