### PR TITLE
nuevo ajuste para heuristica de calculo de costo de envio

### DIFF
--- a/classes/WC_WHQ_Chilexpress_Shipping.php
+++ b/classes/WC_WHQ_Chilexpress_Shipping.php
@@ -117,7 +117,7 @@ function whq_wcchp_init_class() {
 					'packaging_heuristic' => array(
 						'title'       => __( 'Heuristica para calculo de costo de envío', 'whq-wcchp' ),
 						'type'        => 'select',
-						'description' => __( 'Heuristica para calcular el ensamblaje de varios productos en un mismo pedido<br><ul><li>Unir los lados mas angostos (aplicable cuando son productos pequeños)</li><li>Un paquete por producto (recomendable cuando se envian productos mayores y/o en mayor cantidad)</li></ul>', 'whq-wcchp' ),
+						'description' => __( 'Heuristica para calcular el precio a base del ensamblaje de varios productos en un mismo pedido<br><ul><li>- Un solo paquete uniendo los lados mas angostos (recomendable cuando son productos pequeños. método por defecto)</li><li>- Un paquete por producto (recomendable cuando se envian productos mayores y/o en mayor cantidad)</li></ul>', 'whq-wcchp' ),
 						'options'     => array('join_narrow_sides'=>'Unir lados angostos','single_package_per_item'=>'Un paquete por item'),
 						'default'     => 'join_narrow_sides',
 					),
@@ -640,7 +640,7 @@ function whq_wcchp_init_class() {
             	foreach($rates as $key=>$values){
                     $this->add_rate(array(
                         'id' => $values[0],            // service_id
-                        'label' => $value[s1],         // service_label
+                        'label' => $values[1],         // service_label
                         'cost' => $values[2]           // service_cost
                     ));
                 }


### PR DESCRIPTION
se incluye un nuevo ajuste para las heurísticas de calculo de costo de envío

esta vez en un array asociativo (preferí ocupar una descripción textual y no un indice). Ademas se incluyó un valor por defecto
Ojo; en el caso de cualquier desajuste en el método calculate_shipping, si no encuentra un valor siempre recae al método original de sumar los lados mas angostos (eso como doble seguridad)

En el método calculate_shipping se incluyeron condiciones para adaptarse al ajuste nuevo de packaging_heuristic

Se incluye un nuevo método para calcular los costos de envío por item

Ademas se refactorizo el metodo y se externalizaron dos metodos:
get_tarification
y add_rates
para evitar codigo redundante

PD: El PR esta probado en una instalacion