### PR TITLE
Llamadas soap con wsdl en vivo (no de los archivos)

### DIFF
--- a/classes/WC_WHQ_Chilexpress_Shipping.php
+++ b/classes/WC_WHQ_Chilexpress_Shipping.php
@@ -274,7 +274,7 @@ function whq_wcchp_init_class() {
 					$soap_api_enviroment = 'QA';
 				}
 
-				$url    = $whq_wcchp_default['plugin_url'] . 'wsdl/WSDL_GeoReferencia_' . $soap_api_enviroment . '.wsdl';
+				$url    = ($soap_api_enviroment=='QA'?'http://testservices.wschilexpress.com/GeoReferencia?wsdl':'http://ws.ssichilexpress.cl/GeoReferencia?wsdl');
 				$ns     = $whq_wcchp_default['chilexpress_url'] . '/CorpGR/';
 				$route  = 'ConsultarCoberturas';
 				$method = 'reqObtenerCobertura';
@@ -323,7 +323,7 @@ function whq_wcchp_init_class() {
 					$soap_api_enviroment = 'QA';
 				}
 
-				$url    = $whq_wcchp_default['plugin_url'] . 'wsdl/WSDL_GeoReferencia_' .$soap_api_enviroment . '.wsdl';
+				$url    = ($soap_api_enviroment=='QA'?'http://testservices.wschilexpress.com/GeoReferencia?wsdl':'http://ws.ssichilexpress.cl/GeoReferencia?wsdl');
 				$ns     = $whq_wcchp_default['chilexpress_url'] . '/CorpGR/';
 				$route  = 'ConsultarRegiones';
 				$method = 'reqObtenerRegion';

--- a/includes/soap_call.php
+++ b/includes/soap_call.php
@@ -97,7 +97,7 @@ function whq_wcchp_get_tarification($destination, $origin, $weight, $length, $wi
 		$soap_api_enviroment = 'QA';
 	}
 
-	$url    = $whq_wcchp_default['plugin_url'] . 'wsdl/WSDL_Tarificacion_' . $soap_api_enviroment . '.wsdl';
+	$url    = ($soap_api_enviroment=='QA'?'http://testservices.wschilexpress.com/TarificarCourier?wsdl':'http://ws.ssichilexpress.cl/TarificarCourier?wsdl');
 	$ns     = $whq_wcchp_default['chilexpress_url'] . '/TarificaCourier/';
 	$route  = 'TarificarCourier';
 	$method = 'reqValorizarCourier';


### PR DESCRIPTION
Cambiar las llamadas SOAP para ocupar los wsdl que CHilexpress ofrece en vivo.

No ocupar mas los archivos.
De hecho se pueden eliminar...

Por favor probar el fix...